### PR TITLE
Feature/a5 functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.0.17",
+    "@turf/helpers": "^7.3.4",
+    "@turf/points-within-polygon": "^7.3.4",
     "a5-js": "^0.7.2",
     "d3": "^7.9.0",
     "daisyui": "^5.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.17
         version: 4.2.2(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@turf/helpers':
+        specifier: ^7.3.4
+        version: 7.3.4
+      '@turf/points-within-polygon':
+        specifier: ^7.3.4
+        version: 7.3.4
       a5-js:
         specifier: ^0.7.2
         version: 0.7.2
@@ -1138,17 +1144,32 @@ packages:
   '@turf/boolean-clockwise@5.1.5':
     resolution: {integrity: sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==}
 
+  '@turf/boolean-point-in-polygon@7.3.4':
+    resolution: {integrity: sha512-v/4hfyY90Vz9cDgs2GwjQf+Lft8o7mNCLJOTz/iv8SHAIgMMX0czEoIaNVOJr7tBqPqwin1CGwsncrkf5C9n8Q==}
+
   '@turf/clone@5.1.5':
     resolution: {integrity: sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==}
 
   '@turf/helpers@5.1.5':
     resolution: {integrity: sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw==}
 
+  '@turf/helpers@7.3.4':
+    resolution: {integrity: sha512-U/S5qyqgx3WTvg4twaH0WxF3EixoTCfDsmk98g1E3/5e2YKp7JKYZdz0vivsS5/UZLJeZDEElOSFH4pUgp+l7g==}
+
   '@turf/invariant@5.2.0':
     resolution: {integrity: sha512-28RCBGvCYsajVkw2EydpzLdcYyhSA77LovuOvgCJplJWaNVyJYH6BOR3HR9w50MEkPqb/Vc/jdo6I6ermlRtQA==}
 
+  '@turf/invariant@7.3.4':
+    resolution: {integrity: sha512-88Eo4va4rce9sNZs6XiMJowWkikM3cS2TBhaCKlU+GFHdNf8PFEpiU42VDU8q5tOF6/fu21Rvlke5odgOGW4AQ==}
+
   '@turf/meta@5.2.0':
     resolution: {integrity: sha512-ZjQ3Ii62X9FjnK4hhdsbT+64AYRpaI8XMBMcyftEOGSmPMUVnkbvuv3C9geuElAXfQU7Zk1oWGOcrGOD9zr78Q==}
+
+  '@turf/meta@7.3.4':
+    resolution: {integrity: sha512-tlmw9/Hs1p2n0uoHVm1w3ugw1I6L8jv9YZrcdQa4SH5FX5UY0ATrKeIvfA55FlL//PGuYppJp+eyg/0eb4goqw==}
+
+  '@turf/points-within-polygon@7.3.4':
+    resolution: {integrity: sha512-HfT83Iw99zywDfCp+nJwS+JDzH+GdNug0sut9WDjGEznHKoZyAcOk+hGKL/ja8TeCLx9VsZHOiVCQFm+NTgvgA==}
 
   '@turf/rewind@5.1.5':
     resolution: {integrity: sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==}
@@ -2683,6 +2704,9 @@ packages:
 
   png-js@1.0.0:
     resolution: {integrity: sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g==}
+
+  point-in-polygon-hao@1.2.4:
+    resolution: {integrity: sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==}
 
   polylabel@1.1.0:
     resolution: {integrity: sha512-bxaGcA40sL3d6M4hH72Z4NdLqxpXRsCFk8AITYg6x1rn1Ei3izf00UMLklerBZTO49aPA3CYrIwVulx2Bce2pA==}
@@ -4391,19 +4415,52 @@ snapshots:
       '@turf/helpers': 5.1.5
       '@turf/invariant': 5.2.0
 
+  '@turf/boolean-point-in-polygon@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      point-in-polygon-hao: 1.2.4
+      tslib: 2.8.1
+
   '@turf/clone@5.1.5':
     dependencies:
       '@turf/helpers': 5.1.5
 
   '@turf/helpers@5.1.5': {}
 
+  '@turf/helpers@7.3.4':
+    dependencies:
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
   '@turf/invariant@5.2.0':
     dependencies:
       '@turf/helpers': 5.1.5
 
+  '@turf/invariant@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
   '@turf/meta@5.2.0':
     dependencies:
       '@turf/helpers': 5.1.5
+
+  '@turf/meta@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/points-within-polygon@7.3.4':
+    dependencies:
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@turf/helpers': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
   '@turf/rewind@5.1.5':
     dependencies:
@@ -6064,6 +6121,10 @@ snapshots:
   picomatch@4.0.4: {}
 
   png-js@1.0.0: {}
+
+  point-in-polygon-hao@1.2.4:
+    dependencies:
+      robust-predicates: 3.0.3
 
   polylabel@1.1.0:
     dependencies:

--- a/src/utilities/UtilityFunctions.test.tsx
+++ b/src/utilities/UtilityFunctions.test.tsx
@@ -1,5 +1,7 @@
 import { describe, expect, it, test } from "vitest";
-import { getAllA5centroids } from "./utilFuncs";
+import { a5PolygonToCell, getAllA5centroids } from "./utilFuncs";
+import h3SinglePolyMorocco from '../data/H3moroccoHexFeature.json';
+import { Polygon } from "./types";
 
 // describe('test getWindDirection', function() {
 //   test('wind degrees 100: result should be E', () => {
@@ -18,7 +20,7 @@ import { getAllA5centroids } from "./utilFuncs";
 // })
 
 describe('test getAllA5centroids', function() {
-  it('returns valid GeoJSON with expected cellIdHex at Res0 ', async () => {
+  it('returns valid cellIdHex, centroid at Res0 ', async () => {
     const input = 0
     const result = getAllA5centroids(input);
 
@@ -32,7 +34,7 @@ describe('test getAllA5centroids', function() {
     )
   });
 
-  it('returns valid GeoJSON with expected cellIdHex at Res1', async () => {
+  it('returns valid cellIdHex, centroid at Res1', async () => {
     const input = 1
     const result = getAllA5centroids(input);
 
@@ -47,3 +49,13 @@ describe('test getAllA5centroids', function() {
   })
 });
 
+describe('test a5PolygonToCell', function() {
+  it('return the correct cellIdHex array Res0', async () => {
+    const centroids = { cellIdHex: '5380000000000000', centroid: [-10.838189842367342, 33.3067237705403] }
+    const result = a5PolygonToCell([centroids], h3SinglePolyMorocco.geometry as Polygon);
+
+    expect(result).toEqual(
+      expect.arrayContaining(['5380000000000000'])
+    )
+  });
+});

--- a/src/utilities/UtilityFunctions.test.tsx
+++ b/src/utilities/UtilityFunctions.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "vitest";
-import { a5PolygonToCell, getAllA5centroids } from "./utilFuncs";
+import { a5cellIdsToGeoJSON, a5cellIdsToGeometries, a5PolygonToCell, getAllA5centroids } from "./utilFuncs";
 import h3SinglePolyMorocco from '../data/H3moroccoHexFeature.json';
 import { Polygon } from "./types";
 
@@ -51,11 +51,96 @@ describe('test getAllA5centroids', function() {
 
 describe('test a5PolygonToCell', function() {
   it('return the correct cellIdHex array Res0', async () => {
-    const centroids = { cellIdHex: '5380000000000000', centroid: [-10.838189842367342, 33.3067237705403] }
-    const result = a5PolygonToCell([centroids], h3SinglePolyMorocco.geometry as Polygon);
-
+    const centroids = [{ cellIdHex: '5380000000000000', centroid: [-10.838189842367342, 33.3067237705403] },
+    { cellIdHex: '5380028370000000', centroid: [-100.838189842367342, 75.3067237705403] }];
+    const result = a5PolygonToCell(centroids, h3SinglePolyMorocco.geometry as Polygon);
     expect(result).toEqual(
       expect.arrayContaining(['5380000000000000'])
+    )
+  });
+});
+
+describe('test a5cellIdsToGeoJSON', function() {
+  it('returns a GeoJSON Feature Collection with the correct polygons', async () => {
+    const centroids = ['5380000000000000'];
+    const result = a5cellIdsToGeoJSON(centroids);
+    expect(result.features).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          "geometry": {
+            "coordinates": [
+              [
+                [
+                  -139.52242598238394,
+                  55.8635309838565,
+                ],
+                [
+                  -139.52238797387025,
+                  55.86361405638346,
+                ],
+                [
+                  -139.52252621502458,
+                  55.863601018331615,
+                ],
+                [
+                  -139.52260731488064,
+                  55.863527459712444,
+                ],
+                [
+                  -139.5225257989194,
+                  55.86346590272602,
+                ],
+                [
+                  -139.52242598238394,
+                  55.8635309838565,
+                ],
+              ],
+            ],
+            "type": "Polygon",
+          },
+          "properties": {
+            "cellIdHex": "5380000000000000",
+          },
+          "type": "Feature",
+        })
+      ])
+    )
+  });
+});
+
+describe('test a5cellIdsToGeometries', function() {
+  it('returns a', async () => {
+    const centroids = ['5380000000000000'];
+    const result = a5cellIdsToGeometries(centroids);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        [
+          [
+            -139.52242598238394,
+            55.8635309838565,
+          ],
+          [
+            -139.52238797387025,
+            55.86361405638346,
+          ],
+          [
+            -139.52252621502458,
+            55.863601018331615,
+          ],
+          [
+            -139.52260731488064,
+            55.863527459712444,
+          ],
+          [
+            -139.5225257989194,
+            55.86346590272602,
+          ],
+          [
+            -139.52242598238394,
+            55.8635309838565,
+          ],
+        ],
+      ])
     )
   });
 });

--- a/src/utilities/types/index.ts
+++ b/src/utilities/types/index.ts
@@ -35,3 +35,34 @@ export type D3Features = {
   features: d3.Selection<SVGPathElement, unknown, SVGGElement, unknown>
 };
 
+export type Position = [number, number, number?];
+
+export interface LineString {
+  type: 'LineString';
+  coordinates: Array<Position>;
+}
+export interface Polygon {
+  type: 'Polygon';
+  coordinates: Position[][];
+}
+export interface Point {
+  type: 'Point';
+  coordinates: Position;
+}
+
+export type Geometry = LineString | Polygon | Point;
+
+// Properties: Generic to allow any key-value pairs
+export type Properties = { [key: string]: unknown };
+
+export interface Feature<T extends Geometry = Geometry, P = Properties> {
+  type: 'Feature';
+  geometry: T | null;
+  properties: P;
+  id?: string | number;
+}
+
+export interface GeoJSONgeneric<T extends Geometry = Geometry, P = Properties> {
+  type: 'FeatureCollection';
+  features: Feature<T, P>[];
+}

--- a/src/utilities/utilFuncs.ts
+++ b/src/utilities/utilFuncs.ts
@@ -1,7 +1,7 @@
 import { GeoJSONFeature } from "maplibre-gl";
 import * as h3 from 'h3-js';
 import { cellToBoundary, u64ToHex, cellToChildren, cellToLonLat } from "a5-js";
-import { Polygon } from "./types";
+import { Geometry, Polygon } from "./types";
 import { points, polygon } from "@turf/helpers";
 import pointsWithinPolygon from "@turf/points-within-polygon";
 
@@ -107,7 +107,13 @@ export const getA5GeoJSON = (geoJSONfeatures: GeoJSONFeature[], res: number) => 
       if (geometry.type === 'MultiPolygon') {
         geometry.coordinates.forEach((polygonCoords) =>
           pentagons = pentagons.concat(h3.polyfill(polygonCoords, res, true)));
-      } else pentagons = h3.polyfill(geometry.coordinates, res, true);
+        // let's work here first 
+        // get centroids  
+        // get cellIDs 
+        // get GeoJSON 
+      } else {
+        pentagons = h3.polyfill(geometry.coordinates, res, true);
+      }
       // console.log('pentagons', pentagons);
       // console.log('coordinates', geometry.coordinates);
       return { name, pentagons: [...new Set(pentagons)] };
@@ -151,16 +157,7 @@ export const getAllA5centroids = (resolution: number) => {
   }
 
   return cells;
-  //   cells.push({
-  //     type: "Feature",
-  //     geometry: { type: "Polygon", coordinates: [boundary] },
-  //     properties: { cellIdHex, 'centroid': centroid }
-  //   });
-  // }
-  //
-  // return { type: "FeatureCollection", features: cells };
 }
-
 
 export type A5Centroid = {
   cellIdHex: string;
@@ -184,16 +181,34 @@ export type A5Centroid = {
  * @returns Array of cellIdHex that contain that polygon
  *
  */
-export const a5PolygonToCell = (centroids: Array<A5Centroid>, polygonGeometry: Polygon): Array<string> => {
-  console.log(centroids, polygonGeometry);
+export const a5PolygonToCell = (centroids: Array<A5Centroid>, polygonGeometry: Polygon): Array<string | null> => {
+  // console.log(centroids, polygonGeometry);
   const intersections = centroids.map((d) => {
     const poly = polygon(polygonGeometry.coordinates);
     const pnt = points([d.centroid])
     const result = pointsWithinPolygon(pnt, poly)
-    return result?.features[0]?.geometry?.coordinates
+    return result?.features[0]?.geometry?.coordinates[0] ? d.cellIdHex : null;
   })
+  return intersections.filter(item => item != null)
+  // return ['5380000000000000'];
+}
 
-  return ['5380000000000000'];
+export const a5cellIdsToGeoJSON = (cellHexIds: string[]) => {
+  const geoJSONfeatures: GeoJSONFeature[] = cellHexIds.map((d: string) => {
+    const boundary = cellToBoundary(BigInt(d));
+    return {
+      type: "Feature",
+      geometry: { type: "Polygon", coordinates: [boundary] },
+      properties: { 'cellIdHex': d }
+    };
+  });
+  // console.log(geoJSONfeatures)
 
+  return { type: "FeatureCollection", features: geoJSONfeatures };
+}
 
+export const a5cellIdsToGeometries = (cellHexIds: string[]) => {
+  const geometryArray: Geometry[] = cellHexIds.map((d: string) => cellToBoundary(BigInt(d)));
+  console.log('geometries', geometryArray)
+  return geometryArray;
 }

--- a/src/utilities/utilFuncs.ts
+++ b/src/utilities/utilFuncs.ts
@@ -1,6 +1,9 @@
 import { GeoJSONFeature } from "maplibre-gl";
 import * as h3 from 'h3-js';
 import { cellToBoundary, u64ToHex, cellToChildren, cellToLonLat } from "a5-js";
+import { Polygon } from "./types";
+import { points, polygon } from "@turf/helpers";
+import pointsWithinPolygon from "@turf/points-within-polygon";
 
 const splitAtAntimeridian = (coords: number[][]) => {
   let crossesAntimeridian = false;
@@ -91,7 +94,7 @@ export const getH3GeoJSON = (geoJSONfeatures: GeoJSONFeature[], res: number) => 
 }
 
 export const getA5GeoJSON = (geoJSONfeatures: GeoJSONFeature[], res: number) => {
-  console.log('centroids', getAllA5centroids(0));
+  console.log('centroids', getAllA5centroids(2));
   const a5Countries = geoJSONfeatures.map(country => {
     const geometry = country.geometry;
     const name = country.properties.NAME;
@@ -148,9 +151,21 @@ export const getAllA5centroids = (resolution: number) => {
   }
 
   return cells;
+  //   cells.push({
+  //     type: "Feature",
+  //     geometry: { type: "Polygon", coordinates: [boundary] },
+  //     properties: { cellIdHex, 'centroid': centroid }
+  //   });
+  // }
+  //
+  // return { type: "FeatureCollection", features: cells };
 }
 
 
+export type A5Centroid = {
+  cellIdHex: string;
+  centroid: number[];
+}
 /**
  * Proposed workflow for A5 polyfill like function from H3 
  *
@@ -158,17 +173,27 @@ export const getAllA5centroids = (resolution: number) => {
  * 2. Use turf to create a turf polygon object 
  * 3. Iterate through ALL A5 centroids and find which are INSIDE polygon 
  * 4. Push the CellID if centroid in polygon
- * 5. CellIDs to GeoJSON geometry 
- * 6. Return GeoJSON Geometry 
+ * 5. Return array of cellIDs
+ *
+ * Future Function:
+ * 6. CellIDs to GeoJSON geometry 
+ * 7. Return GeoJSON Geometrl
  *
  * @param centroids: Array of objects containing cellID and point
- * @returns A GeoJSON FeatureCollection containing centroid features
+ * @param polygonGeometry: single/multipolygon GeoJSON Geometry
+ * @returns Array of cellIdHex that contain that polygon
  *
- * @example
- * ```ts
- * const geojson = getA5centroids(0);
- * console.log(geojson.features[0].properties.cellIdHex);
- * // → "200000000000000"
- * ```
  */
+export const a5PolygonToCell = (centroids: Array<A5Centroid>, polygonGeometry: Polygon): Array<string> => {
+  console.log(centroids, polygonGeometry);
+  const intersections = centroids.map((d) => {
+    const poly = polygon(polygonGeometry.coordinates);
+    const pnt = points([d.centroid])
+    const result = pointsWithinPolygon(pnt, poly)
+    return result?.features[0]?.geometry?.coordinates
+  })
 
+  return ['5380000000000000'];
+
+
+}


### PR DESCRIPTION
New A5 functions to generate polygons from existing vector data.  
Currently using centroids and turf pointInPolygon, will need more robust coverage for full implementation. 
Updating tests for A5 functions.  